### PR TITLE
Fix matcher response

### DIFF
--- a/samples/teste2.yaml
+++ b/samples/teste2.yaml
@@ -10,4 +10,10 @@ configuration:
         headers:
           content-type: application/json
         body: |
-          {"xpto": "${body.xpto}", "status": "FAIL"}
+          {
+            "xpto": "${body.root.xpto}",
+            "foobar" : "${body.root.foobar}",
+            "queryparam" : "${url.query}",
+            "header" : "${headers.blah}",
+            "status": "OK"
+          }

--- a/src/main/java/br/com/moip/mockkid/controller/MockKidController.java
+++ b/src/main/java/br/com/moip/mockkid/controller/MockKidController.java
@@ -2,6 +2,7 @@ package br.com.moip.mockkid.controller;
 
 import br.com.moip.mockkid.facade.MockKidFacade;
 import br.com.moip.mockkid.model.Configuration;
+import br.com.moip.mockkid.model.MockkidRequest;
 import br.com.moip.mockkid.provider.ConfigurationProvider;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
@@ -36,7 +37,7 @@ public class MockKidController {
 
     @RequestMapping("/**")
     public ResponseEntity mocks(HttpServletRequest request){
-        return facade.discover(request);
+        return facade.discover(new MockkidRequest(request));
     }
 
 }

--- a/src/main/java/br/com/moip/mockkid/facade/MockKidFacade.java
+++ b/src/main/java/br/com/moip/mockkid/facade/MockKidFacade.java
@@ -6,14 +6,16 @@ import br.com.moip.mockkid.model.Response;
 import br.com.moip.mockkid.provider.ConfigurationProvider;
 import br.com.moip.mockkid.service.ResponseEntityFactory;
 import br.com.moip.mockkid.service.ResponseMatcher;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Component;
 
-import javax.servlet.http.HttpServletRequest;
-
 @Component
 public class MockKidFacade {
+
+    private static final Logger logger = LoggerFactory.getLogger(MockKidFacade.class);
 
     @Autowired
     private ConfigurationProvider configurationProvider;
@@ -25,11 +27,17 @@ public class MockKidFacade {
     private ResponseEntityFactory responseEntityFactory;
 
     public ResponseEntity discover(MockkidRequest request) {
-        Configuration matchedConfig = configurationProvider.getConfiguration(request);
-        Response matchedResponse = responseMatcher.getResponse(matchedConfig, request);
-        ResponseEntity result = responseEntityFactory.fromResponse(matchedResponse);
+        logger.info("Processing new request for URI: {}", request.getRequestURI());
 
-        return result;
+        Configuration matchedConfig = configurationProvider.getConfiguration(request);
+
+        logger.info("Matched Configuration: {}", matchedConfig);
+
+        Response matchedResponse = responseMatcher.getResponse(matchedConfig, request);
+
+        logger.info("Matched Response: {}", matchedResponse);
+
+        return responseEntityFactory.fromResponse(matchedResponse);
     }
 
 }

--- a/src/main/java/br/com/moip/mockkid/facade/MockKidFacade.java
+++ b/src/main/java/br/com/moip/mockkid/facade/MockKidFacade.java
@@ -1,6 +1,7 @@
 package br.com.moip.mockkid.facade;
 
 import br.com.moip.mockkid.model.Configuration;
+import br.com.moip.mockkid.model.MockkidRequest;
 import br.com.moip.mockkid.model.Response;
 import br.com.moip.mockkid.provider.ConfigurationProvider;
 import br.com.moip.mockkid.service.ResponseEntityFactory;
@@ -23,7 +24,7 @@ public class MockKidFacade {
     @Autowired
     private ResponseEntityFactory responseEntityFactory;
 
-    public ResponseEntity discover(HttpServletRequest request){
+    public ResponseEntity discover(MockkidRequest request) {
         Configuration matchedConfig = configurationProvider.getConfiguration(request);
         Response matchedResponse = responseMatcher.getResponse(matchedConfig, request);
         ResponseEntity result = responseEntityFactory.fromResponse(matchedResponse);

--- a/src/main/java/br/com/moip/mockkid/model/MockkidRequest.java
+++ b/src/main/java/br/com/moip/mockkid/model/MockkidRequest.java
@@ -1,0 +1,40 @@
+package br.com.moip.mockkid.model;
+
+import javax.servlet.ServletRequest;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletRequestWrapper;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.stream.Collectors;
+
+public class MockkidRequest extends HttpServletRequestWrapper {
+
+    private String body = null;
+
+    /**
+     * Constructs a request object wrapping the given request.
+     *
+     * @param request The request to wrap
+     * @throws IllegalArgumentException if the request is null
+     */
+    public MockkidRequest(HttpServletRequest request) {
+        super(request);
+    }
+
+    /**
+     * See {@link ServletRequest#getInputStream()}
+     */
+    public InputStream getSafeInputStream() throws IOException {
+        return new ByteArrayInputStream(getBody().getBytes(StandardCharsets.UTF_8.name()));
+    }
+
+    private String getBody() throws IOException {
+        if (body == null) {
+            body = this.getReader().lines().collect(Collectors.joining());
+        }
+        return body;
+    }
+
+}

--- a/src/main/java/br/com/moip/mockkid/model/Response.java
+++ b/src/main/java/br/com/moip/mockkid/model/Response.java
@@ -11,6 +11,10 @@ public class Response {
     public Response() {
     }
 
+    public Response(Response response) {
+        this(response.status, response.headers, response.body);
+    }
+
     public Response(Integer status, Map<String, String> headers, String body) {
         this.status = status;
         this.headers = headers;

--- a/src/main/java/br/com/moip/mockkid/service/ConditionalSolver.java
+++ b/src/main/java/br/com/moip/mockkid/service/ConditionalSolver.java
@@ -40,7 +40,7 @@ public class ConditionalSolver {
         return (defaults.isEmpty() ? null : defaults.get(0));
     }
 
-    public boolean solve(Conditional conditional, Map<String, String> variables) {
+    private boolean solve(Conditional conditional, Map<String, String> variables) {
         for (br.com.moip.mockkid.conditional.ConditionalSolver c : conditionals) {
             if (c.type().equals(conditional.getType()) && c.eval(conditional, variables)) return true;
         }

--- a/src/main/java/br/com/moip/mockkid/service/ResponseMatcher.java
+++ b/src/main/java/br/com/moip/mockkid/service/ResponseMatcher.java
@@ -35,14 +35,15 @@ public class ResponseMatcher {
     }
 
     private Response replaceResponseBody(ResponseConfiguration responseConfiguration, Map<String, String> variables) {
-        String body = responseConfiguration.getResponse().getBody();
+        Response response = new Response(responseConfiguration.getResponse());
+        String body = response.getBody();
 
         for (Map.Entry<String, String> entry : variables.entrySet()) {
             body = body.replace("${" + entry.getKey() + "}", entry.getValue());
         }
 
-        responseConfiguration.getResponse().setBody(body);
-        return responseConfiguration.getResponse();
+        response.setBody(body);
+        return response;
     }
 
 }

--- a/src/main/java/br/com/moip/mockkid/service/ResponseMatcher.java
+++ b/src/main/java/br/com/moip/mockkid/service/ResponseMatcher.java
@@ -29,9 +29,8 @@ public class ResponseMatcher {
 
     private Response buildResponse(ResponseConfiguration responseConfiguration, HttpServletRequest request) {
         Map<String, String> variables = variableResolver.resolveResponseBodyVariables(responseConfiguration, request);
-        Response response = replaceResponseBody(responseConfiguration, variables);
 
-        return response;
+        return replaceResponseBody(responseConfiguration, variables);
     }
 
     private Response replaceResponseBody(ResponseConfiguration responseConfiguration, Map<String, String> variables) {

--- a/src/main/java/br/com/moip/mockkid/service/VariableResolver.java
+++ b/src/main/java/br/com/moip/mockkid/service/VariableResolver.java
@@ -9,7 +9,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 import javax.servlet.http.HttpServletRequest;
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;

--- a/src/main/java/br/com/moip/mockkid/service/VariableResolver.java
+++ b/src/main/java/br/com/moip/mockkid/service/VariableResolver.java
@@ -3,10 +3,13 @@ package br.com.moip.mockkid.service;
 import br.com.moip.mockkid.model.Configuration;
 import br.com.moip.mockkid.model.ResponseConfiguration;
 import br.com.moip.mockkid.model.VariableResolvers;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 import javax.servlet.http.HttpServletRequest;
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -19,6 +22,7 @@ import java.util.stream.Collectors;
 public class VariableResolver {
 
     private static final Pattern VARIABLE_PATTERN = Pattern.compile("\\$\\{([a-zA-Z\\.]*)\\}");
+    private static final Logger logger = LoggerFactory.getLogger(VariableResolver.class);
 
     @Autowired
     private VariableResolvers variableResolvers;
@@ -65,4 +69,5 @@ public class VariableResolver {
 
         return null;
     }
+
 }

--- a/src/main/java/br/com/moip/mockkid/variable/resolver/body/JSONBodyVariableResolver.java
+++ b/src/main/java/br/com/moip/mockkid/variable/resolver/body/JSONBodyVariableResolver.java
@@ -1,5 +1,6 @@
 package br.com.moip.mockkid.variable.resolver.body;
 
+import br.com.moip.mockkid.model.MockkidRequest;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
@@ -16,7 +17,8 @@ public class JSONBodyVariableResolver {
 
     public static String extractValueFromJson(String name, HttpServletRequest request) {
         try {
-            BufferedReader reader = new BufferedReader(new InputStreamReader(request.getInputStream()));
+            BufferedReader reader = new BufferedReader(
+                    new InputStreamReader(((MockkidRequest) request).getSafeInputStream()));
             JsonObject parse = (JsonObject) new JsonParser().parse(reader);
             String[] nodes = name.replace("body.", "").split("\\.");
 

--- a/src/main/java/br/com/moip/mockkid/variable/resolver/body/XMLBodyVariableResolver.java
+++ b/src/main/java/br/com/moip/mockkid/variable/resolver/body/XMLBodyVariableResolver.java
@@ -1,5 +1,6 @@
 package br.com.moip.mockkid.variable.resolver.body;
 
+import br.com.moip.mockkid.model.MockkidRequest;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.w3c.dom.Document;
@@ -19,7 +20,7 @@ public class XMLBodyVariableResolver {
             DocumentBuilderFactory builderFactory =
                     DocumentBuilderFactory.newInstance();
             DocumentBuilder builder = builderFactory.newDocumentBuilder();
-            Document document = builder.parse(request.getInputStream());
+            Document document = builder.parse(((MockkidRequest) request).getSafeInputStream());
 
             XPath xPath =  XPathFactory.newInstance().newXPath();
             String expression = name.replace("body", "").replaceAll("\\.", "/");

--- a/src/main/resources/configuration/teste2.yaml
+++ b/src/main/resources/configuration/teste2.yaml
@@ -10,4 +10,4 @@ configuration:
         headers:
           content-type: application/json
         body: |
-          {"xpto": "${body.xpto}", "status": "FAIL"}
+          {"xpto": "${body.xpto}", "status": "${body.status}}"}

--- a/src/main/resources/configuration/teste2.yaml
+++ b/src/main/resources/configuration/teste2.yaml
@@ -10,4 +10,10 @@ configuration:
         headers:
           content-type: application/json
         body: |
-          {"xpto": "${body.xpto}", "status": "${body.status}}"}
+          {
+            "xpto": "${body.root.xpto}",
+            "foobar" : "${body.root.foobar}",
+            "queryparam" : "${url.query}",
+            "header" : "${headers.blah}",
+            "status": "OK"
+          }

--- a/src/test/java/br/com/moip/mockkid/service/ResponseEntityFactoryTest.java
+++ b/src/test/java/br/com/moip/mockkid/service/ResponseEntityFactoryTest.java
@@ -30,9 +30,7 @@ public class ResponseEntityFactoryTest {
         assertEquals("{\"hello\": \"world\"}", responseEntity.getBody());
         assertEquals(201, responseEntity.getStatusCodeValue());
 
-        headerMap.keySet().forEach(key -> {
-            assertEquals(headerMap.get(key), responseEntity.getHeaders().get(key).get(0));
-        });
+        headerMap.keySet().forEach(key -> assertEquals(headerMap.get(key), responseEntity.getHeaders().get(key).get(0)));
     }
 
 }

--- a/src/test/java/br/com/moip/mockkid/variable/resolver/BodyVariableResolverTest.java
+++ b/src/test/java/br/com/moip/mockkid/variable/resolver/BodyVariableResolverTest.java
@@ -1,5 +1,6 @@
 package br.com.moip.mockkid.variable.resolver;
 
+import br.com.moip.mockkid.model.MockkidRequest;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
@@ -7,7 +8,6 @@ import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
 import org.springframework.mock.web.DelegatingServletInputStream;
 
-import javax.servlet.http.HttpServletRequest;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 
@@ -21,7 +21,7 @@ public class BodyVariableResolverTest {
     private BodyVariableResolver resolver = new BodyVariableResolver();
 
     @Mock
-    private HttpServletRequest request;
+    private MockkidRequest request;
 
     @Before
     public void setUp() {
@@ -61,6 +61,6 @@ public class BodyVariableResolverTest {
 
     protected void configureRequestWithBody(String body) throws IOException {
         DelegatingServletInputStream stream = new DelegatingServletInputStream(new ByteArrayInputStream(body.getBytes()));
-        Mockito.when(request.getInputStream()).thenReturn(stream);
+        Mockito.when(request.getSafeInputStream()).thenReturn(stream);
     }
 }

--- a/src/test/java/br/com/moip/mockkid/variable/resolver/body/JsonBodyVariableResolverTest.java
+++ b/src/test/java/br/com/moip/mockkid/variable/resolver/body/JsonBodyVariableResolverTest.java
@@ -1,5 +1,6 @@
 package br.com.moip.mockkid.variable.resolver.body;
 
+import br.com.moip.mockkid.model.MockkidRequest;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
@@ -7,7 +8,6 @@ import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
 import org.springframework.mock.web.DelegatingServletInputStream;
 
-import javax.servlet.http.HttpServletRequest;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 
@@ -16,7 +16,7 @@ import static org.junit.Assert.assertEquals;
 public class JsonBodyVariableResolverTest {
 
     @Mock
-    private HttpServletRequest request;
+    private MockkidRequest request;
 
     @Before
     public void setUp() {
@@ -43,7 +43,7 @@ public class JsonBodyVariableResolverTest {
 
     private void configureRequestWithBody(String body) throws IOException {
         DelegatingServletInputStream stream = new DelegatingServletInputStream(new ByteArrayInputStream(body.getBytes()));
-        Mockito.when(request.getInputStream()).thenReturn(stream);
+        Mockito.when(request.getSafeInputStream()).thenReturn(stream);
     }
 
 }

--- a/src/test/java/br/com/moip/mockkid/variable/resolver/body/XMLBodyVariableResolverTest.java
+++ b/src/test/java/br/com/moip/mockkid/variable/resolver/body/XMLBodyVariableResolverTest.java
@@ -1,5 +1,6 @@
 package br.com.moip.mockkid.variable.resolver.body;
 
+import br.com.moip.mockkid.model.MockkidRequest;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
@@ -7,7 +8,6 @@ import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
 import org.springframework.mock.web.DelegatingServletInputStream;
 
-import javax.servlet.http.HttpServletRequest;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 
@@ -16,7 +16,7 @@ import static org.junit.Assert.assertEquals;
 public class XMLBodyVariableResolverTest {
 
     @Mock
-    private HttpServletRequest request;
+    private MockkidRequest request;
 
     @Before
     public void setUp() {
@@ -43,7 +43,7 @@ public class XMLBodyVariableResolverTest {
 
     private void configureRequestWithBody(String body) throws IOException {
         DelegatingServletInputStream stream = new DelegatingServletInputStream(new ByteArrayInputStream(body.getBytes()));
-        Mockito.when(request.getInputStream()).thenReturn(stream);
+        Mockito.when(request.getSafeInputStream()).thenReturn(stream);
     }
 
 }


### PR DESCRIPTION
- Wraps request InputStream so we can use more than one body variable
- Fixes variable value cache (only first calculated value was ever used)
- Added strategic logging
- Changed default POST example to include all variable use cases