### PR TITLE
Adding support for variables with dash 

### DIFF
--- a/src/main/java/br/com/moip/mockkid/conditional/solver/JavascriptConditionalSolver.java
+++ b/src/main/java/br/com/moip/mockkid/conditional/solver/JavascriptConditionalSolver.java
@@ -24,7 +24,7 @@ public class JavascriptConditionalSolver implements ConditionalSolver {
         try {
             return (boolean) buildJSEngine(variables).eval(normalize(conditional, variables));
         } catch (Exception e) {
-            logger.error("Error evaluating javascript function: " + conditional.getEval(), e);
+            logger.error("Error evaluating javascript function: {} -> message: {}", conditional.getEval(), e.getMessage());
             return false;
         }
     }
@@ -36,7 +36,7 @@ public class JavascriptConditionalSolver implements ConditionalSolver {
      */
     private ScriptEngine buildJSEngine(Map<String, String> variables) {
         ScriptEngine engine = new ScriptEngineManager().getEngineByName("js");
-        variables.forEach((k,v) -> engine.put(k.replace(".", "_"), v));
+        variables.forEach((k,v) -> engine.put(k.replaceAll("[\\.\\-]", "_"), v));
         return engine;
     }
 
@@ -49,7 +49,7 @@ public class JavascriptConditionalSolver implements ConditionalSolver {
     private String normalize(Conditional conditional, Map<String, String> variables) {
         String eval = conditional.getEval();
         for (String variable : variables.keySet()) {
-            eval = eval.replace("${" + variable + "}", variable.replace(".", "_"));
+            eval = eval.replace("${" + variable + "}", variable.replaceAll("[\\.\\-]", "_"));
         }
         return eval;
     }

--- a/src/main/java/br/com/moip/mockkid/model/Response.java
+++ b/src/main/java/br/com/moip/mockkid/model/Response.java
@@ -50,7 +50,7 @@ public class Response {
         return "Response{" +
                 "status=" + status +
                 ", headers=" + headers +
-                ", body='" + body + '\'' +
+                ", body=OMITTED" +
                 '}';
     }
 

--- a/src/main/java/br/com/moip/mockkid/service/VariableResolver.java
+++ b/src/main/java/br/com/moip/mockkid/service/VariableResolver.java
@@ -23,7 +23,7 @@ import java.util.stream.Stream;
 @Component
 public class VariableResolver {
 
-    private static final Pattern VARIABLE_PATTERN = Pattern.compile("\\$\\{([a-zA-Z\\._]*)\\}");
+    private static final Pattern VARIABLE_PATTERN = Pattern.compile("\\$\\{([a-zA-Z\\._\\-]*)\\}");
     private static final Logger logger = LoggerFactory.getLogger(VariableResolver.class);
 
     @Autowired

--- a/src/test/java/br/com/moip/mockkid/conditional/solver/JavascriptConditionalSolverTest.java
+++ b/src/test/java/br/com/moip/mockkid/conditional/solver/JavascriptConditionalSolverTest.java
@@ -51,4 +51,19 @@ public class JavascriptConditionalSolverTest {
         assertFalse(jsConditionalSolver.eval(conditional, variables));
     }
 
+    @Test
+    public void evalShouldWorkForVariableWithDot() {
+        Map<String, String> variables = of("with.dot", "value");
+        Conditional conditional = new Conditional(ConditionalType.JAVASCRIPT, "${with.dot} == \"value\"");
+
+        assertTrue(jsConditionalSolver.eval(conditional, variables));
+    }
+
+    @Test
+    public void evalShouldWorkForVariableWithDash() {
+        Map<String, String> variables = of("with-dash", "value");
+        Conditional conditional = new Conditional(ConditionalType.JAVASCRIPT, "${with-dash} == \"value\"");
+
+        assertTrue(jsConditionalSolver.eval(conditional, variables));
+    }
 }

--- a/src/test/java/br/com/moip/mockkid/service/VariableResolverTest.java
+++ b/src/test/java/br/com/moip/mockkid/service/VariableResolverTest.java
@@ -49,7 +49,9 @@ public class VariableResolverTest {
         Map<String, String> variables = variableResolver.resolve(getConfiguration(), null);
         assertEquals("expression_resolved", variables.get("expression"));
         assertEquals("var_resolved", variables.get("var"));
-        assertEquals(2, variables.size());
+        assertEquals("with.dot_resolved", variables.get("with.dot"));
+        assertEquals("with-dash_resolved", variables.get("with-dash"));
+        assertEquals(4, variables.size());
     }
 
     @Test
@@ -78,7 +80,9 @@ public class VariableResolverTest {
         List<ResponseConfiguration> responseConfigurations = Lists.newArrayList(
             new ResponseConfiguration("c1", new Conditional(JAVASCRIPT, "${expression}"), null),
             new ResponseConfiguration("c2", new Conditional(EQUALS, "var", null), null),
-            new ResponseConfiguration("c3", null, null)
+            new ResponseConfiguration("c3", null, null),
+            new ResponseConfiguration("c4", new Conditional(JAVASCRIPT, "${with.dot}"), null),
+            new ResponseConfiguration("c5", new Conditional(JAVASCRIPT, "${with-dash}"), null)
         );
 
         return new Configuration(new Endpoint("/endpoint", Method.POST), responseConfigurations);


### PR DESCRIPTION
(is interpreted as subtraction in javascript)
Needed to be able to write Cielo configuration. Example:
```
conditional:
        type: JAVASCRIPT
        eval: ${body.requisicao-transacao} && ${body.requisicao-transacao.dados-portador.nome-portador}.toLowerCase().indexOf('cancel') !== -1
```